### PR TITLE
Specify password authentication for initdb and adjust pwfile permissions

### DIFF
--- a/infra/dev/psql/scripts/configure-psql.sh
+++ b/infra/dev/psql/scripts/configure-psql.sh
@@ -3,10 +3,11 @@
 temp_pw_file=$(mktemp)
 master_password=$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c16)
 echo ${master_password} > ${temp_pw_file}
+sudo chown postgres:postgres "${temp_pw_file}"
 
-export PGSETUP_INITDB_OPTIONS="-U ${master_username} --pwfile ${temp_pw_file}"
-sudo postgresql-setup initdb
-rm -f ${temp_pw_file}
+export PGSETUP_INITDB_OPTIONS="-A password -U ${master_username} --pwfile ${temp_pw_file}"
+sudo -E postgresql-setup initdb
+sudo rm -f ${temp_pw_file}
 
 ctx instance runtime-properties master_username ${master_username}
 ctx instance runtime-properties master_password ${master_password}


### PR DESCRIPTION
The current `configure-psql.sh` script will report success (and the appropriate capabilities appear in the deployment), but attempts to log in to Postgres via the `psql` command on the host fail. This is because current versions of Postgres use [peer authentication](https://stackoverflow.com/questions/18664074/getting-error-peer-authentication-failed-for-user-postgres-when-trying-to-ge) by default in their `pg_hba.conf` file.

The fix proposed in this PR adds the `-A password` switch to `initdb`, which allows password authentication to work.

Adding this switch revealed that the permissions on the temporary password file were preventing `initdb` from reading it. By default, `mktemp` creates the temporary file with `0600` permissions. Since this is run as the `centos` user, the `postgres` user was unable to read the password file.

I confirmed this fix works by uploading the updated blueprints to my Cloudify manager (v6.2) and creating a `dev-small` environment.